### PR TITLE
use compatible cuda version; yield progressive outputs

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -1,10 +1,13 @@
 build:
   gpu: true
+  cuda: "10.2"
   python_version: "3.8"
   system_packages:
     - "libgl1-mesa-glx"
     - "libglib2.0-0"
   python_packages:
+    - "torch==1.10.0"
+    - "torchvision==0.11.1"
     - "cmake==3.21.2"
     - "numpy==1.20.1"
     - "ipython==7.21.0"
@@ -20,7 +23,6 @@ build:
     - "tqdm==4.62.3"
     - "scikit-image==0.18.3"
   run:
-    - pip install torch==1.7.1 torchvision==0.8.2
     - git clone https://github.com/BachiLi/diffvg && cd diffvg && git submodule update --init --recursive && CMAKE_PREFIX_PATH=$(pyenv prefix) DIFFVG_CUDA=1 python setup.py install
     - pip install git+https://github.com/openai/CLIP.git --no-deps
 predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -680,7 +680,7 @@ def style_clip_draw(prompt, style_path, \
 
     img = render_drawing(shapes, shape_groups, canvas_width, canvas_height, t).detach().cpu().numpy()[0]
     save_img(img, str(out_path))
-    return out_path
+    yield out_path
 
 
 import cog
@@ -722,8 +722,9 @@ class Predictor(cog.Predictor):
         # shutil.copy(str(image), input_path)
         print(device)
         print(style_image)
-        out_path = style_clip_draw(prompt, str(style_image), num_paths=num_paths,\
+        for path in style_clip_draw(prompt, str(style_image), num_paths=num_paths,\
                           num_iter=num_iterations, style_opt_freq=style_opt_freq,
-                          style_opt_iter=style_opt_iter)
+                          style_opt_iter=style_opt_iter):
+            yield path
 
-        return out_path
+        return path


### PR DESCRIPTION
Hi Peter! I was running into issues with Torch so I upgraded to 1.10.0 and it worked locally. However, when pushing to Replicate I needed to set CUDA==10.2 because the NVIDIA driver version on Replicate nodes is less than required by CUDA 11.3.